### PR TITLE
[FIX] Bitfinex Websocket API 1_1 URI

### DIFF
--- a/src/exchanges/bitfinex/BitfinexCommon.ts
+++ b/src/exchanges/bitfinex/BitfinexCommon.ts
@@ -19,7 +19,7 @@ export const ORDERBOOK_PRECISION: { [index: string]: string } = {
 };
 
 export const WEBSOCKET_API_VERSION = 1.1;
-export const BITFINEX_WS_FEED = 'wss://api2.bitfinex.com:3000/ws';
+export const BITFINEX_WS_FEED = 'wss://api.bitfinex.com/ws';
 
 /**
  * A map of supported Coinbase Pro books to the equivalent Bitfinex book


### PR DESCRIPTION
## What has changed
According to the [Bitfinex Docs](https://docs.bitfinex.com/docs/ws-general) the Websocket API 1.1 URI is `wss://api.bitfinex.com/ws` instead of `wss://api2.bitfinex.com:3000/ws`

If you clone master and attempt to run `src/samples/liveBitfinexOrderbook.ts` or `src/samples/bitfinexWSdemo.ts` both will fail. 

Changing the URI to `wss://api.bitfinex.com/ws` in `src/exchanges/bitfinex/BitfinexCommon.ts` appears to resolve the issue. 